### PR TITLE
프로미스 캐치 구현, captureException 구현,  os.version 에러 수정

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acent/browser",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "sentry like monitoring system sdk ",
   "main": "dist/index.js",
   "repository": {
@@ -31,7 +31,7 @@
     "start": "tsc-watch --onSuccess \" node dist/index.js\" "
   },
   "dependencies": {
-    "@acent/core": "0.1.0"
+    "@acent/core": "0.1.1"
   },
   "bugs": {
     "url": "https://github.com/boostcamp-2020/Project11-C-Web-FE-Performance-Monitoring-SDK/issues"

--- a/browser/src/index.ts
+++ b/browser/src/index.ts
@@ -3,4 +3,6 @@ import * as sdk from './sdk';
 
 const init = sdk.init;
 const recentErrorId = tracer.recentErrorId;
-export { init, tracer, recentErrorId };
+const captureException = tracer.captureException;
+const startErrorCapturing = tracer.startErrorCapturing;
+export { init, startErrorCapturing, captureException, recentErrorId };

--- a/browser/src/tracer.ts
+++ b/browser/src/tracer.ts
@@ -11,7 +11,7 @@ interface TagsType {
   url: string;
 }
 
-const getUserInfo = () => {
+const getTags = () => {
   return {
     browser: navigator.userAgent,
     appVersion: navigator.appVersion,
@@ -23,9 +23,29 @@ const getUserInfo = () => {
   };
 };
 
+const captureException = (error: Error) => {
+  const tags: TagsType = getTags();
+  pocket.putInfo(tags);
+
+  const data = {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    errArea: {},
+    tags: tags,
+    date: new Date().getTime(),
+  };
+
+  transport.sendLog(data).then(res => {
+    if (typeof res === 'string') {
+      recentErrorId.value = res;
+    }
+  });
+};
+
 const startErrorCapturing = () => {
   window.onunhandledrejection = async (event: PromiseRejectionEvent) => {
-    const tags: TagsType = getUserInfo();
+    const tags: TagsType = getTags();
     pocket.putInfo(tags);
 
     const data = {
@@ -44,7 +64,7 @@ const startErrorCapturing = () => {
   };
 
   window.onerror = function (errorMsg, url, lineNumber, column, errorObj) {
-    const tags: TagsType = getUserInfo();
+    const tags: TagsType = getTags();
     pocket.putInfo(tags);
 
     const data = {
@@ -64,4 +84,4 @@ const startErrorCapturing = () => {
   };
 };
 
-export { startErrorCapturing, recentErrorId };
+export { startErrorCapturing, captureException, recentErrorId };

--- a/browser/yarn.lock
+++ b/browser/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@acent/core@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@acent/core/-/core-0.1.0.tgz#7395ff7e0930ec5c77f0c5fc7c27d741dbc8e32f"
-  integrity sha512-CBAYWmQ9kYMlMUc01kgNu1sXj40Q5jAMHwAF74Kwcx4IZ0xynwoTfXuFPJqUvrrHg3EMd/eUr4OAPO4MzHp4xQ==
+"@acent/core@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@acent/core/-/core-0.1.1.tgz#83faa8eeac4e16ff4405951770c16b444c671886"
+  integrity sha512-YShx8O+jbMQHhai7f3AW7Eo3vBJ1uDzPkYAM/SCEKkEridVwz3SIotsNaKaBDSEgLFGXSFPeQjsZYkltsVJwmg==
   dependencies:
     axios "^0.21.0"
 

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acent/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "sentry like monitoring system sdk ",
   "main": "dist/index.js",
   "repository": {

--- a/core/src/errorHelper.ts
+++ b/core/src/errorHelper.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 
-const errorParser = (error: Error) => {
-  const errorPathInfo: string = error.stack.split('\n')[1];
+const errorParser = (error: string) => {
+  const errorPathInfo: string = error.split('\n')[1];
 
   const errReg: RegExp = /(.js|.jsx|.ts|.tsx):\d+/;
   const errorLine: string = errReg.exec(errorPathInfo)[0];
@@ -13,7 +13,7 @@ const errorParser = (error: Error) => {
   return { errorPathInfo, errorLineNumber, splitToken };
 };
 
-const errorTracer = (err: Error) => {
+const errorTracer = (err: string) => {
   const { errorPathInfo, errorLineNumber, splitToken } = errorParser(err);
   const errMap: Map<number, string> = new Map();
 

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acent/node",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "sentry like monitoring system sdk ",
   "main": "dist/index.js",
   "repository": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acent/node",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "sentry like monitoring system sdk ",
   "main": "dist/index.js",
   "repository": {
@@ -31,7 +31,7 @@
     "start": "tsc-watch --onSuccess \" node dist/index.js\" "
   },
   "dependencies": {
-    "@acent/core": "0.1.0"
+    "@acent/core": "0.1.1"
   },
   "bugs": {
     "url": "https://github.com/boostcamp-2020/Project11-C-Web-FE-Performance-Monitoring-SDK/issues"

--- a/node/src/handlers.ts
+++ b/node/src/handlers.ts
@@ -33,7 +33,7 @@ const getRequestInfo = (req: Request) => {
     language: req.headers['accept-language'],
     method: req.method,
     url: req.url,
-    body: String(req.body),
+    body: JSON.stringify(req.body),
     type: os.type(),
     arch: os.arch(),
     platform: os.platform(),

--- a/node/src/handlers.ts
+++ b/node/src/handlers.ts
@@ -1,35 +1,16 @@
 import { transport, errorHelper, pocket } from '@acent/core';
 import * as os from 'os';
+import { reqInfoType, tagType, errorArea, Reason } from './interface';
 
-interface reqInfoType {
-  browser: string;
-  language: string;
-  method: string;
-  url: string;
-  body: any;
-  type: string;
-  arch: string;
-  platform: string;
-  hostName: string;
-  osVersion: string;
-  runtimeName: string;
-  runtimeVersion: string;
-}
+const getOs = () => {
+  try {
+    const osVersion = os.version();
 
-interface tagType {
-  type: string;
-  arch: string;
-  platform: string;
-  hostName: string;
-  osVersion: string;
-  runtimeName: string;
-  runtimeVersion: string;
-}
-
-interface errorArea {
-  key: number[];
-  value: string[];
-}
+    return osVersion;
+  } catch (error) {
+    return os.type();
+  }
+};
 
 const getTags = () => {
   const tags: tagType = {
@@ -37,7 +18,7 @@ const getTags = () => {
     arch: os.arch(),
     platform: os.platform(),
     hostName: os.hostname(),
-    osVersion: os.version(),
+    osVersion: getOs(),
     runtimeName: process.release.name,
     runtimeVersion: process.version,
   };
@@ -52,12 +33,12 @@ const getRequestInfo = (req: Request) => {
     language: req.headers['accept-language'],
     method: req.method,
     url: req.url,
-    body: req.body,
+    body: String(req.body),
     type: os.type(),
     arch: os.arch(),
     platform: os.platform(),
     hostName: os.hostname(),
-    osVersion: os.version(),
+    osVersion: getOs(),
     runtimeName: process.release.name,
     runtimeVersion: process.version,
   };
@@ -79,7 +60,7 @@ const isInternalServerError = (err: Error) => {
 const startErrorCapturing = () => {
   process.on('uncaughtException', async (err: Error, _origin) => {
     console.log(err);
-    const errArea: errorArea = errorHelper.errorTracer(err);
+    const errArea: errorArea = errorHelper.errorTracer(err.stack);
     const tags: tagType = getTags();
 
     try {
@@ -100,6 +81,55 @@ const startErrorCapturing = () => {
   });
 };
 
+const captureException = async (err: Error, req: Request, res: Response) => {
+  const errName: string = err.name;
+  const errMessage: string = err.message;
+  const errStack: string = err.stack;
+  const errArea: errorArea = errorHelper.errorTracer(err.stack);
+  const tags: reqInfoType | tagType = req ? getRequestInfo(req) : getTags();
+
+  try {
+    const result: string | boolean = await transport.sendLog({
+      name: errName,
+      message: errMessage,
+      stack: errStack,
+      errArea: errArea,
+      tags: tags,
+      date: new Date().getTime(), // timestamp도? 정렬할 때...
+    });
+
+    if (result && isInternalServerError(err)) {
+      res['eventId'] = result;
+      return;
+    }
+  } catch (error) {
+    throw error;
+  }
+};
+
+const catchUnhandledRejection = () => {
+  process.on('unhandledRejection', async (reason: Reason, promise) => {
+    console.log(reason);
+    const errArea: errorArea = errorHelper.errorTracer(reason.stack);
+    const tags: tagType = getTags();
+
+    try {
+      const result: string | boolean = await transport.sendLog({
+        name: reason.name,
+        message: reason.message,
+        stack: reason.stack,
+        errArea: errArea,
+        tags: tags,
+        date: new Date().getTime(),
+      });
+
+      console.log('Error ID : ', result);
+    } catch (error) {
+      throw error;
+    }
+  });
+};
+
 const errorHandler = () => {
   const errorMiddleware = async (
     err: Error,
@@ -110,7 +140,7 @@ const errorHandler = () => {
     const errName: string = err.name;
     const errMessage: string = err.message;
     const errStack: string = err.stack;
-    const errArea: errorArea = errorHelper.errorTracer(err);
+    const errArea: errorArea = errorHelper.errorTracer(err.stack);
     const tags: reqInfoType = getRequestInfo(req);
 
     try {
@@ -138,4 +168,9 @@ const errorHandler = () => {
   return errorMiddleware;
 };
 
-export { errorHandler, startErrorCapturing };
+export {
+  errorHandler,
+  startErrorCapturing,
+  catchUnhandledRejection,
+  captureException,
+};

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -4,4 +4,12 @@ import * as Handlers from './handlers';
 const init = sdk.init;
 const errorHandler = Handlers.errorHandler;
 const startErrorCapturing = Handlers.startErrorCapturing;
-export { init, errorHandler, startErrorCapturing };
+const catchUnhandledRejection = Handlers.catchUnhandledRejection;
+const captureException = Handlers.captureException;
+export {
+  init,
+  errorHandler,
+  startErrorCapturing,
+  catchUnhandledRejection,
+  captureException,
+};

--- a/node/src/interface.ts
+++ b/node/src/interface.ts
@@ -1,0 +1,35 @@
+export interface reqInfoType {
+  browser: string;
+  language: string;
+  method: string;
+  url: string;
+  body: string;
+  type: string;
+  arch: string;
+  platform: string;
+  hostName: string;
+  osVersion: string;
+  runtimeName: string;
+  runtimeVersion: string;
+}
+
+export interface tagType {
+  type: string;
+  arch: string;
+  platform: string;
+  hostName: string;
+  osVersion: string;
+  runtimeName: string;
+  runtimeVersion: string;
+}
+
+export interface errorArea {
+  key: number[];
+  value: string[];
+}
+
+export interface Reason {
+  name: string;
+  stack: string;
+  message: string;
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@acent/core@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@acent/core/-/core-0.1.0.tgz#7395ff7e0930ec5c77f0c5fc7c27d741dbc8e32f"
-  integrity sha512-CBAYWmQ9kYMlMUc01kgNu1sXj40Q5jAMHwAF74Kwcx4IZ0xynwoTfXuFPJqUvrrHg3EMd/eUr4OAPO4MzHp4xQ==
+"@acent/core@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@acent/core/-/core-0.1.1.tgz#83faa8eeac4e16ff4405951770c16b444c671886"
+  integrity sha512-YShx8O+jbMQHhai7f3AW7Eo3vBJ1uDzPkYAM/SCEKkEridVwz3SIotsNaKaBDSEgLFGXSFPeQjsZYkltsVJwmg==
   dependencies:
     axios "^0.21.0"
 


### PR DESCRIPTION
- 프로미스 에러를 잡을 수 있는 로직들을 구현
- try-catch에서 쓸 수 있는 captureException 구현
ex.
try {
 ...
} catch(error) {
  Acent.captureException(error);
}
- os.version 에러 수정
- req.body를 string 타입으로 변경